### PR TITLE
llvm commit 184591a: replace getElementType with getPointerElementType

### DIFF
--- a/lib/MemoryAnalysisModules/AcyclicAA.cpp
+++ b/lib/MemoryAnalysisModules/AcyclicAA.cpp
@@ -395,7 +395,7 @@ void AcyclicAA::accumulateRecursiveTypes(Function &fcn, TypeSet &visited,
         if (BitCastInst *bcI = dyn_cast<BitCastInst>(UserI)) {
           if (PointerType *new_ptr = dyn_cast<PointerType>(bcI->getDestTy())) {
             if (PointerType *new_base =
-                    dyn_cast<PointerType>(new_ptr->getElementType())) {
+                    dyn_cast<PointerType>(new_ptr->getPointerElementType())) {
 
               // if( gep->getNumIndices() != 1 )
               //  continue;
@@ -424,7 +424,7 @@ void AcyclicAA::accumulateRecursiveTypes(Function &fcn, TypeSet &visited,
     }
 
     // recursive GEP!
-    if (ptr->getElementType() != base)
+    if (ptr->getPointerElementType() != base)
       continue;
 
     if (visited.count(base))

--- a/lib/MemoryAnalysisModules/ArrayOfStructures.cpp
+++ b/lib/MemoryAnalysisModules/ArrayOfStructures.cpp
@@ -185,7 +185,7 @@ public:
     // aka first index of the gep)
     const PointerType *gepPtrOpType =
         dyn_cast<PointerType>(gep1->getPointerOperandType());
-    if (gepPtrOpType && gepPtrOpType->getElementType()->isStructTy() &&
+    if (gepPtrOpType && gepPtrOpType->getPointerElementType()->isStructTy() &&
         gep1->getNumIndices() > 1 && gep2->getNumIndices() > 1) {
 
       bool staticallyDiffIndexFound = false;

--- a/lib/MemoryAnalysisModules/FieldMallocAA.cpp
+++ b/lib/MemoryAnalysisModules/FieldMallocAA.cpp
@@ -107,7 +107,7 @@ public:
       return;
 
     PointerType *ptrOpTy = cast<PointerType>(gep->getPointerOperandType());
-    if (!ptrOpTy->getElementType()->isPointerTy())
+    if (!ptrOpTy->getPointerElementType()->isPointerTy())
       return;
 
     bool isSane = TAA->isSane(ptrOpTy);
@@ -158,9 +158,9 @@ public:
     PointerType *Ty1 = dyn_cast<PointerType>(GEP1->getPointerOperandType());
     PointerType *Ty2 = dyn_cast<PointerType>(GEP2->getPointerOperandType());
 
-    if (!Ty1 || !isa<StructType>(Ty1->getElementType()))
+    if (!Ty1 || !isa<StructType>(Ty1->getPointerElementType()))
       return MayAlias;
-    if (!Ty2 || !isa<StructType>(Ty2->getElementType()))
+    if (!Ty2 || !isa<StructType>(Ty2->getPointerElementType()))
       return MayAlias;
 
     if (badFieldTypes.count(Ty1) || badFieldTypes.count(Ty2))

--- a/lib/MemoryAnalysisModules/GlobalMallocAA.cpp
+++ b/lib/MemoryAnalysisModules/GlobalMallocAA.cpp
@@ -146,7 +146,7 @@ public:
 
     for (GlobalIt global = M.global_begin(); global != M.global_end();
          ++global) {
-      Type *type = global->getType()->getElementType();
+      Type *type = global->getType()->getPointerElementType();
       if (type->isPointerTy()) {
         for (UseIt use = global->user_begin(); use != global->user_end();
              ++use) {

--- a/lib/MemoryAnalysisModules/KillFlow.cpp
+++ b/lib/MemoryAnalysisModules/KillFlow.cpp
@@ -322,8 +322,8 @@ bool KillFlow::killAllIdx(const Value *killidx, const Value *basePtr,
   // that's the case then no need to check the dominated idx, it will be
   // contained in one of the indexes of the kill.
   const PointerType *basePtrTy = dyn_cast<PointerType>(basePtr->getType());
-  if (basePtrTy && basePtrTy->getElementType()->isArrayTy() && idxID == 1) {
-    ArrayType *auType = dyn_cast<ArrayType>(basePtrTy->getElementType());
+  if (basePtrTy && basePtrTy->getPointerElementType()->isArrayTy() && idxID == 1) {
+    ArrayType *auType = dyn_cast<ArrayType>(basePtrTy->getPointerElementType());
     uint64_t numOfElemInAU = auType->getNumElements();
     // check that the killidx starts from 0 up to numOfElemInAU with step 1
 
@@ -392,7 +392,7 @@ bool KillFlow::killAllIdx(const Value *killidx, const Value *basePtr,
   const PointerType *baseObjTy = dyn_cast<PointerType>(basePtr->getType());
   if (!baseObjTy)
     return false;
-  const Type *elemObjTy = baseObjTy->getElementType();
+  const Type *elemObjTy = baseObjTy->getPointerElementType();
 
   if (!elemObjTy->isIntegerTy() && !elemObjTy->isFloatingPointTy() &&
       !elemObjTy->isPointerTy() && !elemObjTy->isStructTy()) {
@@ -400,10 +400,10 @@ bool KillFlow::killAllIdx(const Value *killidx, const Value *basePtr,
     return false;
   }
 
-  const Type *type = baseGVSrc->getType()->getElementType();
+  const Type *type = baseGVSrc->getType()->getPointerElementType();
   if (!type->isPointerTy())
     return false;
-  const Type *elemType = (dyn_cast<PointerType>(type))->getElementType();
+  const Type *elemType = (dyn_cast<PointerType>(type))->getPointerElementType();
 
   if (elemType != elemObjTy)
     return false;

--- a/lib/MemoryAnalysisModules/LoopAA.cpp
+++ b/lib/MemoryAnalysisModules/LoopAA.cpp
@@ -675,7 +675,7 @@ LoopAA::ModRefResult AAToLoopAA::modref(const Instruction *A,
         const Value *ptrA = getMemOper(A);
         PointerType *pty = cast<PointerType>(ptrA->getType());
         const unsigned sizeA =
-            getDataLayout()->getTypeSizeInBits(pty->getElementType()) / 8;
+            getDataLayout()->getTypeSizeInBits(pty->getPointerElementType()) / 8;
 
         // Conservatively reverse the query (see note a t top of fcn)
         ModRefResult r = Raise(AA->getModRefInfo(B, ptrA, sizeA));
@@ -688,7 +688,7 @@ LoopAA::ModRefResult AAToLoopAA::modref(const Instruction *A,
       } else if (const Value *ptrB = getMemOper(B)) {
         PointerType *pty = cast<PointerType>(ptrB->getType());
         const unsigned sizeB =
-            getDataLayout()->getTypeSizeInBits(pty->getElementType()) / 8;
+            getDataLayout()->getTypeSizeInBits(pty->getPointerElementType()) / 8;
 
         ModRefResult r = Raise(AA->getModRefInfo(A, ptrB, sizeB));
         if (r == NoModRef)

--- a/lib/MemoryAnalysisModules/NoEscapeFieldsAA.cpp
+++ b/lib/MemoryAnalysisModules/NoEscapeFieldsAA.cpp
@@ -100,7 +100,7 @@ void NonCapturedFieldsAnalysis::eraseDefinitions(StructType *structty,
 void NonCapturedFieldsAnalysis::collectDefsFromGlobalVariable(
     GlobalVariable *gv) {
   PointerType *pointer_to_global = gv->getType();
-  Type *ty = pointer_to_global->getElementType();
+  Type *ty = pointer_to_global->getPointerElementType();
 
   if (gv->hasInitializer())
     collectDefsFromGlobalVariable(gv, ty, gv->getInitializer());
@@ -126,12 +126,12 @@ void NonCapturedFieldsAnalysis::collectDefsFromGlobalVariable(
 
   else if (ArrayType *arrty = dyn_cast<ArrayType>(ty))
     for (unsigned i = 0, N = arrty->getNumElements(); i < N; ++i)
-      collectDefsFromGlobalVariable(gv, arrty->getElementType(),
+      collectDefsFromGlobalVariable(gv, arrty->getPointerElementType(),
                                     initor->getAggregateElement(i));
 
   else if (VectorType *vecty = dyn_cast<VectorType>(ty))
     for (unsigned i = 0, N = vecty->getArrayNumElements(); i < N; ++i)
-      collectDefsFromGlobalVariable(gv, vecty->getElementType(),
+      collectDefsFromGlobalVariable(gv, vecty->getPointerElementType(),
                                     initor->getAggregateElement(i));
 }
 
@@ -230,7 +230,7 @@ bool checkRawStructIndexing(const Value *val, StructType **structBaseOut,
       if (const BitCastInst *bcI = dyn_cast<BitCastInst>(U)) {
         if (PointerType *dstT = dyn_cast<PointerType>(bcI->getDestTy())) {
           if (StructType *structTy =
-                  dyn_cast<StructType>(dstT->getElementType())) {
+                  dyn_cast<StructType>(dstT->getPointerElementType())) {
 
             // get index. since we have i8*, will be byte offset. Check if
             // we have a field at this offset for the found struct
@@ -269,7 +269,7 @@ bool checkRawStructIndexing(const Value *val, StructType **structBaseOut,
       if (BitCastInst *bcI = dyn_cast<BitCastInst>(U)) {
         if (PointerType *dstT = dyn_cast<PointerType>(bcI->getDestTy())) {
           if (StructType *structTy =
-                  dyn_cast<StructType>(dstT->getElementType())) {
+                  dyn_cast<StructType>(dstT->getPointerElementType())) {
 
             if (structTy->getNumElements() == 0)
               continue;
@@ -277,7 +277,7 @@ bool checkRawStructIndexing(const Value *val, StructType **structBaseOut,
             // check that the type of the first element of the struct matches
             // with the pointer type of the destTy of the bitcast
             if (structTy->getElementType(0) !=
-                cast<PointerType>(cI->getDestTy())->getElementType())
+                cast<PointerType>(cI->getDestTy())->getPointerElementType())
               continue;
 
             *structBaseOut = structTy;
@@ -319,7 +319,7 @@ bool NonCapturedFieldsAnalysis::isFieldPointer(const Value *value,
   if (!ptr)
     return false;
 
-  *structBaseOut = dyn_cast<StructType>(ptr->getElementType());
+  *structBaseOut = dyn_cast<StructType>(ptr->getPointerElementType());
 
   if (!*structBaseOut)
     return false;

--- a/lib/MemoryAnalysisModules/TypeAA.cpp
+++ b/lib/MemoryAnalysisModules/TypeAA.cpp
@@ -344,16 +344,16 @@ bool TypeSanityAnalysis::addInsane(Type *t) {
 
   PointerType *ptrty = dyn_cast<PointerType>(t);
   if (ptrty)
-    addInsane(ptrty->getElementType());
+    addInsane(ptrty->getPointerElementType());
 
   // Sequential types (array, vector)
   auto *vec= dyn_cast<VectorType>(t);
   if (vec)
-    addInsane(vec->getElementType());
+    addInsane(vec->getPointerElementType());
 
   auto *arr = dyn_cast<ArrayType>(t);
   if (arr)
-    addInsane(arr->getElementType());
+    addInsane(arr->getPointerElementType());
 
   // Composite type (including struct, union)
   auto *composite = dyn_cast<StructType>(t);
@@ -512,11 +512,11 @@ bool TypeSanityAnalysis::isSane(Type *t) const {
 // flatten arrays-of/pointers-to/vectors-of to the element types, recursively.
 Type *TypeSanityAnalysis::getBaseType(Type *t) {
   if (auto *arr = dyn_cast<ArrayType>(t))
-    return getBaseType(arr->getElementType());
+    return getBaseType(arr->getPointerElementType());
   if (auto *vec = dyn_cast<VectorType>(t))
-    return getBaseType(vec->getElementType());
+    return getBaseType(vec->getPointerElementType());
   else if (PointerType *ptr = dyn_cast<PointerType>(t))
-    return getBaseType(ptr->getElementType());
+    return getBaseType(ptr->getPointerElementType());
   else
     return t;
 }
@@ -580,11 +580,11 @@ bool TypeSanityAnalysis::typeContainedWithin(Type *container,
   //  (i.e. access to type int[] may access all of the
   //   elements of the array)
   if (auto *arrty = dyn_cast<ArrayType>(container)) {
-    if (typeContainedWithin(arrty->getElementType(), element))
+    if (typeContainedWithin(arrty->getPointerElementType(), element))
       return true;
   }
   if (auto *vecty= dyn_cast<VectorType>(container)) {
-    if (typeContainedWithin(vecty->getElementType(), element))
+    if (typeContainedWithin(vecty->getPointerElementType(), element))
       return true;
   }
 
@@ -630,7 +630,7 @@ LoopAA::AliasResult TypeAA::aliasCheck(const Pointer &P1, TemporalRelation rel,
   if (!PT1 || !PT2)
     return NoAlias;
 
-  Type *elt1 = PT1->getElementType(), *elt2 = PT2->getElementType();
+  Type *elt1 = PT1->getPointerElementType(), *elt2 = PT2->getPointerElementType();
 
   TypeSanityAnalysis &tsa = getAnalysis<TypeSanityAnalysis>();
 
@@ -677,7 +677,7 @@ LoopAA::AliasResult TypeAA::aliasCheck(const Pointer &P1, TemporalRelation rel,
 
     const Value *parent_i = gep_i->getPointerOperand();
     Type *parentty_i =
-        dyn_cast<PointerType>(parent_i->getType())->getElementType();
+        dyn_cast<PointerType>(parent_i->getType())->getPointerElementType();
     if (!parentty_i || !tsa.isSane(parentty_i))
       return MayAlias;
 
@@ -689,7 +689,7 @@ LoopAA::AliasResult TypeAA::aliasCheck(const Pointer &P1, TemporalRelation rel,
 
       const Value *parent_j = gep_j->getPointerOperand();
       Type *parentty_j =
-          dyn_cast<PointerType>(parent_j->getType())->getElementType();
+          dyn_cast<PointerType>(parent_j->getType())->getPointerElementType();
       if (!parentty_j || !tsa.isSane(parentty_j))
         return MayAlias;
 

--- a/lib/Utilities/AAvsOracle.cpp
+++ b/lib/Utilities/AAvsOracle.cpp
@@ -60,8 +60,8 @@ bool AAvsOracle_EarlyHelper::gather(Function *oracle, Truths &collection,
       continue;
     }
 
-    const unsigned s1 = td.getTypeSizeInBits(pty1->getElementType()) / 8,
-                   s2 = td.getTypeSizeInBits(pty2->getElementType()) / 8;
+    const unsigned s1 = td.getTypeSizeInBits(pty1->getPointerElementType()) / 8,
+                   s2 = td.getTypeSizeInBits(pty2->getPointerElementType()) / 8;
 
     collection.push_back(Truth());
     collection.back().desc = desc;

--- a/lib/Utilities/GetSize.cpp
+++ b/lib/Utilities/GetSize.cpp
@@ -24,15 +24,16 @@ unsigned getSize(const Value *value, const DataLayout *TD) {
 unsigned getTargetSize(const Value *value, const DataLayout *TD) {
   Type *type = value->getType();
 
+  // FIXME: getElementType is deprecated
   Type *targetType;
   if (auto seqType = dyn_cast<ArrayType>(type))
-    targetType = seqType->getElementType();
+    targetType = seqType->getPointerElementType();
   if (auto seqType = dyn_cast<VectorType>(type))
-    targetType = seqType->getElementType();
+    targetType = seqType->getPointerElementType();
   else {
     PointerType *pType = dyn_cast<PointerType>(type);
     assert(pType && "Must be a SequentialType or PointerType");
-    targetType = pType->getElementType();
+    targetType = pType->getPointerElementType();
   }
 
   return getSize(targetType, TD);

--- a/lib/Utilities/GlobalMalloc.cpp
+++ b/lib/Utilities/GlobalMalloc.cpp
@@ -61,7 +61,7 @@ bool liberty::findNoCaptureGlobalSrcs(const GlobalValue *global,
 bool liberty::findNoCaptureGlobalMallocSrcs(
     const GlobalValue *global, std::vector<const Instruction *> &mallocSrcs,
     const TargetLibraryInfo *tli) {
-  Type *type = global->getType()->getElementType();
+  Type *type = global->getType()->getPointerElementType();
   if (!type->isPointerTy())
     return false;
   std::vector<const Instruction *> srcs;


### PR DESCRIPTION
Change to remove warnings related to deprecated getElementType