### PR TITLE
Don't assume a specific generator

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,6 +3,7 @@ SCAF_INSTALL_RELEASE?=$(shell pwd)/scaf-install-release
 SVF_AVAILABLE?=0
 JOBS?=16
 SPECULATION_MODULES?=1
+GENERATOR?=Unix Makefiles
 
 CC=clang
 CXX=clang++
@@ -24,13 +25,13 @@ uninstall:
 scaf-debug:
 	mkdir -p scaf-build-debug
 	cd ./scaf-build-debug && \
-	cmake -DCMAKE_INSTALL_PREFIX="$(SCAF_INSTALL_DEBUG)" -DCMAKE_BUILD_TYPE=Debug -DLLVM_ENABLE_UNWIND_TABLES=On -DCMAKE_CXX_FLAGS="-std=c++17" -DSVF_AVAILABLE=$(SVF_AVAILABLE) $(BUILD_SPECULATION) ../ && \
-	make -j${JOBS} && \
-	make install
+	cmake -G "$(GENERATOR)" -DCMAKE_INSTALL_PREFIX="$(SCAF_INSTALL_DEBUG)" -DCMAKE_BUILD_TYPE=Debug -DLLVM_ENABLE_UNWIND_TABLES=On -DCMAKE_CXX_FLAGS="-std=c++17" -DSVF_AVAILABLE=$(SVF_AVAILABLE) $(BUILD_SPECULATION) ../ && \
+	cmake --build . -j${JOBS} && \
+	cmake --install .
 
 scaf-release:
 	mkdir -p scaf-build-release
 	cd ./scaf-build-release && \
-	cmake -DCMAKE_INSTALL_PREFIX="$(SCAF_INSTALL_RELEASE)" -DCMAKE_BUILD_TYPE=Release -DCMAKE_CXX_FLAGS="-std=c++17" -DSVF_AVAILABLE=$(SVF_AVAILABLE) $(BUILD_SPECULATION) ../ && \
-	make -j${JOBS} && \
-	make install
+	cmake -G "$(GENERATOR)" -DCMAKE_INSTALL_PREFIX="$(SCAF_INSTALL_RELEASE)" -DCMAKE_BUILD_TYPE=Release -DCMAKE_CXX_FLAGS="-std=c++17" -DSVF_AVAILABLE=$(SVF_AVAILABLE) $(BUILD_SPECULATION) ../ && \
+	cmake --build . -j${JOBS} && \
+	cmake --install .


### PR DESCRIPTION
- Allowing builds to work with any generator (e.g. `ninja`), not only `make`
- `make` is still the default behavior

This allow generators to be consistent when SCAF is included in another project that uses a different generator.